### PR TITLE
feat(sentiment): harden news layer — market-flow filter, evidence floor, event-override off by default

### DIFF
--- a/backend/analysis/event_taxonomy.py
+++ b/backend/analysis/event_taxonomy.py
@@ -27,12 +27,71 @@ EVENT_TYPES: tuple[EventType, ...] = (
 )
 EVENT_TAXONOMY = EVENT_TYPES
 
+# Weight of the hard-event polarity in the event_override blend (rest goes to raw
+# LLM sentiment). Module constant so it can be tuned/measured via m27 --event-ab.
+EVENT_OVERRIDE_WEIGHT = 0.65
+
+# Market/flow/list-roundup headlines that are NOT company-specific corporate events.
+# These must never trigger a strong event_override; they were empirically dragging
+# sentiment IC down (M27 diagnosis 2026-06-15: event delta -0.0146). Detected first
+# and excluded from hard-event classification so an incidental polarity keyword
+# (e.g. "下滑" inside "市场下滑") cannot misfire as an earnings_warning.
+MARKET_FLOW_KEYWORDS: tuple[str, ...] = (
+    "资金流", "主力净", "净流入", "净流出", "大宗交易", "杠杆资金", "两融",
+    "千股千评", "涨幅榜", "跌幅榜", "龙虎榜", "北向资金", "南向资金", "成交额",
+    "特大单", "主力动向", "基金浮亏", "基金浮盈", "板块异动", "概念涨", "概念跌",
+)
+# Roundup / list headlines tagged loosely to many symbols ("XX股一览", "7只个股…").
+_LIST_HEADLINE_KEYWORDS: tuple[str, ...] = (
+    "一览", "名单", "股大", "只个股", "多股", "股获", "股名单",
+)
+
+
+def is_market_flow(title: str) -> bool:
+    """True if a headline is market/fund-flow/list noise, not a company-specific event."""
+    text = str(title)
+    if any(k in text for k in MARKET_FLOW_KEYWORDS):
+        return True
+    return any(k in text for k in _LIST_HEADLINE_KEYWORDS)
+
+
+def is_company_specific(
+    title: str, company_aliases: list[str] | tuple[str, ...] | None = None
+) -> bool:
+    """True if a headline plausibly carries company-specific signal.
+
+    Always rejects market/flow/list noise. When ``company_aliases`` (e.g. the stock
+    name + code) are given, the headline must also mention one of them — this is what
+    catches cross-company contamination (a 长鑫-IPO headline loosely tagged to 兆易).
+    """
+    text = str(title)
+    if is_market_flow(text):
+        return False
+    aliases = [str(a) for a in (company_aliases or []) if a]
+    if aliases and not any(a in text for a in aliases):
+        return False
+    return True
+
+
+def company_specific_titles(
+    titles: list[str] | tuple[str, ...],
+    company_aliases: list[str] | tuple[str, ...] | None = None,
+) -> list[str]:
+    """Keep only headlines that are company-specific (see ``is_company_specific``)."""
+    return [str(t) for t in titles if is_company_specific(t, company_aliases)]
+
 
 def classify_events(events: list[str] | tuple[str, ...]) -> list[dict]:
-    """Classify event strings into the local A-share taxonomy."""
+    """Classify event strings into the local A-share taxonomy.
+
+    Market/flow/list noise is skipped up front so it cannot be misclassified as a
+    hard corporate event via an incidental keyword match.
+    """
     classified: list[dict] = []
     for event in events:
         text = str(event)
+        if is_market_flow(text):
+            continue
         for event_type in EVENT_TYPES:
             if any(keyword in text for keyword in event_type.keywords):
                 classified.append({
@@ -69,19 +128,38 @@ def build_event_extraction_prompt(symbol: str | None, titles: list[str]) -> str:
     )
 
 
-def event_score(sentiment: float, events: list[str] | tuple[str, ...]) -> dict:
-    """Return an event-aware score in [-1, 1], falling back to sentiment when no event matches."""
+def event_score(
+    sentiment: float,
+    events: list[str] | tuple[str, ...],
+    *,
+    enable_override: bool | None = None,
+) -> dict:
+    """Return an event-aware score in [-1, 1].
+
+    The event_override blend is gated by ``enable_override`` (defaults to
+    ``settings.sentiment_event_override_enabled``, which is OFF). When disabled, the
+    raw sentiment is kept (mode ``sentiment_fallback``) but matched event types are
+    still reported for observability. The override was measured net-negative for IC
+    (M27 diagnosis 2026-06-15) — keep it off unless a clean OOS re-test earns it back.
+    """
     clipped_sentiment = max(-1.0, min(1.0, float(sentiment or 0.0)))
     classified = classify_events(events)
-    if not classified:
+    if enable_override is None:
+        try:
+            from backend.config import settings
+
+            enable_override = bool(settings.sentiment_event_override_enabled)
+        except Exception:
+            enable_override = False
+    if not classified or not enable_override:
         return {
             "event_score": clipped_sentiment,
             "event_score_mode": "sentiment_fallback",
-            "event_types": [],
+            "event_types": classified,
         }
 
     polarity_avg = sum(item["polarity"] for item in classified) / len(classified)
-    score = 0.65 * polarity_avg + 0.35 * clipped_sentiment
+    score = EVENT_OVERRIDE_WEIGHT * polarity_avg + (1.0 - EVENT_OVERRIDE_WEIGHT) * clipped_sentiment
     return {
         "event_score": round(max(-1.0, min(1.0, score)), 4),
         "event_score_mode": "event_override",
@@ -89,12 +167,19 @@ def event_score(sentiment: float, events: list[str] | tuple[str, ...]) -> dict:
     }
 
 
-def apply_event_score(sentiment_result: dict[str, Any], titles: list[str] | None = None) -> dict[str, Any]:
+def apply_event_score(
+    sentiment_result: dict[str, Any],
+    titles: list[str] | None = None,
+    *,
+    enable_override: bool | None = None,
+) -> dict[str, Any]:
     """Add event-aware scoring to an analyze_news-style result."""
     out = dict(sentiment_result)
     event_texts: list[str] = []
     if titles:
         event_texts.extend(titles)
     event_texts.extend(str(item) for item in out.get("key_events", []) or [])
-    out.update(event_score(float(out.get("sentiment") or 0.0), event_texts))
+    out.update(
+        event_score(float(out.get("sentiment") or 0.0), event_texts, enable_override=enable_override)
+    )
     return out

--- a/backend/analysis/sentiment.py
+++ b/backend/analysis/sentiment.py
@@ -4,7 +4,7 @@ import json
 from collections import OrderedDict
 from datetime import UTC, datetime
 
-from backend.analysis.event_taxonomy import apply_event_score
+from backend.analysis.event_taxonomy import apply_event_score, company_specific_titles
 from backend.config import settings
 from backend.llm import get_provider, has_runtime_llm_provider
 
@@ -55,6 +55,20 @@ _DISABLED_FALLBACK = {
     "key_events": [],
     "event_score": 0.0,
     "event_score_mode": "sentiment_fallback",
+    "event_types": [],
+}
+# Evidence floor: when a symbol's window has no company-specific headline (only
+# sector/fund-flow/list noise), neutralise sentiment instead of scoring noise.
+# Prevents the M27 whipsaw (e.g. 兆易 603986: 2 sector-IPO headlines, 0 company
+# news → -71.3 sentiment). Skips the LLM call entirely, so it is also cheaper.
+_NOISE_ONLY_FALLBACK = {
+    "sentiment": 0.0,
+    "summary": "仅板块/资金流新闻，无个股特定信号，情感置中",
+    "impact": "short",
+    "key_events": [],
+    "low_confidence": True,
+    "event_score": 0.0,
+    "event_score_mode": "evidence_floor",
     "event_types": [],
 }
 
@@ -158,28 +172,37 @@ def _persistent_cache_set(key: str, titles_hash: str, symbol: str | None, value:
         return
 
 
-def analyze_news(titles: list[str], symbol: str | None = None) -> dict:
+def analyze_news(
+    titles: list[str],
+    symbol: str | None = None,
+    company_aliases: list[str] | None = None,
+) -> dict:
     """
     输入新闻标题列表，返回情感分析结果。
     {sentiment: float, summary: str, impact: str, key_events: list}
     相同股票+标题集合优先命中进程内和 SQLite 缓存，避免重复消耗 LLM 配额。
+    company_aliases（股票名/代码等别名）用于个股相关性过滤与证据地板；不传则只过滤行情/资金流噪声。
     """
     if not titles:
         return apply_event_score(_FALLBACK, [])
     if not has_runtime_llm_provider(settings):
         return apply_event_score(_DISABLED_FALLBACK, titles)
+    # Evidence floor: no company-specific headline (only noise / cross-company) → neutral, skip LLM.
+    analysis_titles = company_specific_titles(titles, company_aliases)
+    if not analysis_titles:
+        return dict(_NOISE_ONLY_FALLBACK)
 
-    cache_key, titles_hash = _cache_key(titles, symbol)
+    cache_key, titles_hash = _cache_key(analysis_titles, symbol)
     cached = _cache_get(cache_key)
     if cached is not None:
-        return apply_event_score(cached, titles)
+        return apply_event_score(cached, analysis_titles)
     cached = _persistent_cache_get(cache_key)
     if cached is not None:
         _cache_set(cache_key, cached)
-        return apply_event_score(cached, titles)
+        return apply_event_score(cached, analysis_titles)
 
     context = f"股票代码：{symbol}\n" if symbol else ""
-    prompt = context + "新闻标题：\n" + "\n".join(f"- {t}" for t in titles[:15])
+    prompt = context + "新闻标题：\n" + "\n".join(f"- {t}" for t in analysis_titles[:15])
 
     data = get_provider().complete_structured(
         prompt=prompt,
@@ -205,11 +228,11 @@ def analyze_news(titles: list[str], symbol: str | None = None) -> dict:
             "event_score": 0.0,
             "event_score_mode": "sentiment_fallback",
             "event_types": [],
-        }, titles)
+        }, analysis_titles)
 
     data["sentiment"] = max(-1.0, min(1.0, float(data.get("sentiment", 0))))
     data["key_events"] = data.get("key_events", [])[:3]
-    data = apply_event_score(data, titles)
+    data = apply_event_score(data, analysis_titles)
     _cache_set(cache_key, data)
     _persistent_cache_set(cache_key, titles_hash, symbol, data)
     return dict(data)

--- a/backend/backtest/news_cache.py
+++ b/backend/backtest/news_cache.py
@@ -69,6 +69,16 @@ def _fetch_titles(symbol: str, date: str, db, lookback_days: int = 3) -> list[st
     return [r[0] for r in rows if r[0]]
 
 
+def _company_aliases_for_symbol(symbol: str, db) -> list[str] | None:
+    """Return name+symbol aliases when Stock metadata is available."""
+    from backend.data.database import Stock
+
+    stock = db.query(Stock).filter(Stock.symbol == symbol).first()
+    if stock is None or not stock.name:
+        return None
+    return [stock.name, symbol]
+
+
 def get_or_backfill(
     symbol: str,
     date: str,
@@ -105,7 +115,11 @@ def get_or_backfill(
         }
     else:
         from backend.analysis.sentiment import analyze_news
-        result = analyze_news(titles, symbol=symbol)
+        result = analyze_news(
+            titles,
+            symbol=symbol,
+            company_aliases=_company_aliases_for_symbol(symbol, db),
+        )
 
     # 写回缓存（即使是空结果也缓存，避免每次都重查 NewsItem）
     cache[key] = result
@@ -144,7 +158,11 @@ def backfill_all(
 
         try:
             from backend.analysis.sentiment import analyze_news
-            result = analyze_news(titles, symbol=s.symbol)
+            result = analyze_news(
+                titles,
+                symbol=s.symbol,
+                company_aliases=_company_aliases_for_symbol(s.symbol, db),
+            )
             if not result.get("key_events") and result.get("summary") == "解析失败":
                 stats["llm_fail"] += 1
             cache[key] = result

--- a/backend/config.py
+++ b/backend/config.py
@@ -106,6 +106,11 @@ class Settings(BaseSettings):
     weight_technical: float = 0.6
     weight_sentiment: float = 0.4
     new_framework_entry_threshold: float = 25.0
+    # Event-taxonomy override (0.65×事件极性 blend). Default OFF: the M27 sentiment IC
+    # diagnosis (2026-06-15) measured event delta consistently negative across every
+    # variant tested (-0.0027 / -0.0146 / -0.0280), i.e. the override only subtracts IC.
+    # Kept behind a flag so it can be re-enabled for a clean single-provider OOS re-test.
+    sentiment_event_override_enabled: bool = False
 
     # Signal profile: legacy Qlib framework or current new framework.
     paper_trading_profile: str = "auto"  # auto / test1_legacy_qlib / new_framework

--- a/backend/jobs/postmarket.py
+++ b/backend/jobs/postmarket.py
@@ -148,7 +148,8 @@ def _postmarket_news_sentiment(stock, db) -> dict:
             logger.info("Tavily补充 %s: +%d条 (DB=%d条)",
                         stock.symbol, len(tavily_titles), len(titles) - len(tavily_titles))
 
-    sentiment_result = analyze_news(titles, symbol=stock.symbol)
+    company_aliases = [a for a in (stock.name, stock.symbol) if a]
+    sentiment_result = analyze_news(titles, symbol=stock.symbol, company_aliases=company_aliases)
     sentiment_result["news_audit"] = [
         {
             "title": audit.title,

--- a/backend/tools/m27_alpha_diagnostic.py
+++ b/backend/tools/m27_alpha_diagnostic.py
@@ -598,7 +598,9 @@ def _event_ab_row_frame(
         polarity_score = sentiment["polarity_score"]
         polarity_source = sentiment["polarity_source"]
         polarity_available = polarity_score is not None
-        adjusted = event_score(polarity_score or 0.0, titles)
+        # Force the override ON here: this A/B harness exists to measure the override's
+        # counterfactual IC effect, independent of the production default (which is OFF).
+        adjusted = event_score(polarity_score or 0.0, titles, enable_override=True)
         event_available = polarity_available or adjusted["event_score_mode"] == "event_override"
 
         ab_rows.append({

--- a/tests/test_m27_alpha_event_universe.py
+++ b/tests/test_m27_alpha_event_universe.py
@@ -32,8 +32,11 @@ def test_event_taxonomy_scores_events_and_falls_back_to_polarity():
     positive = apply_event_score(
         {"sentiment": -0.1, "key_events": []},
         ["公司公告获得重大合同并中标算力项目"],
+        enable_override=True,  # override is opt-in (default OFF per M27 IC diagnosis)
     )
-    neutral = apply_event_score({"sentiment": 0.2, "key_events": []}, ["普通经营动态"])
+    neutral = apply_event_score(
+        {"sentiment": 0.2, "key_events": []}, ["普通经营动态"], enable_override=True
+    )
 
     assert positive["event_score_mode"] == "event_override"
     assert positive["event_score"] > 0

--- a/tests/test_m27_m28_integration.py
+++ b/tests/test_m27_m28_integration.py
@@ -30,6 +30,7 @@ def test_event_taxonomy_overrides_sentiment_when_event_matches():
     result = apply_event_score(
         {"sentiment": -0.2, "key_events": ["公司获得重大合同订单"]},
         [],
+        enable_override=True,  # override is opt-in (default OFF per M27 IC diagnosis)
     )
 
     assert result["event_score_mode"] == "event_override"

--- a/tests/test_news_sentiment_pack.py
+++ b/tests/test_news_sentiment_pack.py
@@ -1,0 +1,201 @@
+"""Tests for the M27.x news sentiment hardening: market-flow filter, hard-event-only
+override, and the company-evidence floor (2026-06-15 sentiment IC diagnosis follow-up)."""
+from __future__ import annotations
+
+from datetime import datetime
+
+import backend.analysis.sentiment as sentiment
+from backend.analysis.event_taxonomy import (
+    classify_events,
+    company_specific_titles,
+    event_score,
+    is_company_specific,
+    is_market_flow,
+)
+
+# ---- market-flow / relevance detection ---------------------------------------
+
+def test_market_flow_detects_fund_flow_and_lists():
+    assert is_market_flow("主力动向：6月10日特大单净流出542.55亿元")
+    assert is_market_flow("7只个股大宗交易超5000万元")
+    assert is_market_flow("收盘价创历史新高股一览")
+    assert is_market_flow("54股获杠杆资金净买入超亿元")
+    assert is_market_flow("汽车芯片概念涨4.59%，主力资金净流入这些股")
+
+
+def test_company_specific_keeps_real_company_news():
+    assert is_company_specific("兆易创新：拟回购公司股份用于股权激励")
+    assert is_company_specific("北方华创公告：中标某半导体设备订单")
+    assert not is_company_specific("91股特大单净流入资金超2亿元")
+
+
+def test_company_specific_titles_filters_noise():
+    titles = [
+        "兆易创新发布业绩预增公告",       # keep
+        "7只个股大宗交易超5000万元",       # drop (list)
+        "主力资金净流入这些股",           # drop (flow)
+    ]
+    assert company_specific_titles(titles) == ["兆易创新发布业绩预增公告"]
+
+
+def test_company_aliases_catch_cross_company_contamination():
+    # 长鑫-IPO headlines loosely tagged to 兆易: not market noise, but not about 兆易.
+    titles = [
+        "长鑫上市在即 存储炒作能否有二波",
+        "兆易创新参与臻宝科技战略配售",
+    ]
+    kept = company_specific_titles(titles, company_aliases=["兆易创新", "兆易", "603986"])
+    assert kept == ["兆易创新参与臻宝科技战略配售"]
+
+
+# ---- classify_events no longer misfires on market noise ----------------------
+
+def test_market_noise_not_misclassified_as_hard_event():
+    # "下滑" would historically match earnings_warning; inside market noise it must not.
+    assert classify_events(["大盘下滑，两融余额三连降"]) == []
+    assert classify_events(["基金浮亏名单出炉"]) == []
+
+
+def test_real_hard_event_still_classifies():
+    out = classify_events(["公司发布业绩预增公告，净利润预增"])
+    assert out and out[0]["code"] == "earnings_beat"
+    assert out[0]["polarity"] == 1
+
+
+# ---- event_score: only hard events override ----------------------------------
+
+def test_event_score_market_flow_only_falls_back_to_raw():
+    # Even with override explicitly enabled, market-flow noise must not override.
+    res = event_score(0.42, ["主力净流入榜单", "7只个股大宗交易"], enable_override=True)
+    assert res["event_score_mode"] == "sentiment_fallback"
+    assert res["event_score"] == 0.42  # raw kept, no override
+
+
+def test_event_score_override_off_by_default():
+    # Default (settings flag OFF) keeps raw sentiment even on a real hard event.
+    res = event_score(0.0, ["公司收到监管处罚决定书，被立案调查"])
+    assert res["event_score_mode"] == "sentiment_fallback"
+    assert res["event_score"] == 0.0
+    assert res["event_types"][0]["code"] == "regulatory_penalty"  # still reported
+
+
+def test_event_score_hard_event_overrides_when_enabled():
+    res = event_score(0.0, ["公司收到监管处罚决定书，被立案调查"], enable_override=True)
+    assert res["event_score_mode"] == "event_override"
+    assert res["event_score"] < 0  # negative hard event drives it down
+
+
+# ---- analyze_news evidence floor (no company news -> neutral, no LLM call) ----
+
+def test_analyze_news_evidence_floor_neutralises_and_skips_llm(monkeypatch):
+    monkeypatch.setattr(sentiment, "has_runtime_llm_provider", lambda *_a, **_k: True)
+
+    def _boom(*_a, **_k):  # must NOT be called when only noise is present
+        raise AssertionError("LLM provider called on noise-only window")
+
+    monkeypatch.setattr(sentiment, "get_provider", _boom)
+
+    # The 兆易 603986 whipsaw window: sector-IPO headlines, zero company news.
+    res = sentiment.analyze_news(
+        ["长鑫上市在即 存储炒作能否有二波", "长鑫科技上市在即：撑起3万亿产业链"],
+        symbol="603986",
+        company_aliases=["兆易创新", "兆易", "603986"],
+    )
+    assert res["sentiment"] == 0.0
+    assert res["event_score_mode"] == "evidence_floor"
+    assert res.get("low_confidence") is True
+
+
+def test_analyze_news_keeps_company_news_path(monkeypatch):
+    monkeypatch.setattr(sentiment, "has_runtime_llm_provider", lambda *_a, **_k: True)
+    sentiment._INPROC_CACHE.clear() if hasattr(sentiment, "_INPROC_CACHE") else None
+
+    called = {"n": 0}
+
+    class _Prov:
+        def complete_structured(self, **_k):
+            called["n"] += 1
+            return {"sentiment": 0.6, "summary": "利好", "impact": "short", "key_events": []}
+
+    monkeypatch.setattr(sentiment, "get_provider", lambda: _Prov())
+    monkeypatch.setattr(sentiment, "_cache_get", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_persistent_cache_get", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_cache_set", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_persistent_cache_set", lambda *_a, **_k: None)
+
+    res = sentiment.analyze_news(["兆易创新发布业绩预增公告"], symbol="603986")
+    assert called["n"] == 1  # company news -> LLM is consulted
+    assert res["sentiment"] == 0.6
+
+
+def test_analyze_news_sends_only_company_specific_titles_to_llm(monkeypatch):
+    monkeypatch.setattr(sentiment, "has_runtime_llm_provider", lambda *_a, **_k: True)
+    monkeypatch.setattr(sentiment, "_cache_get", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_persistent_cache_get", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_cache_set", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_persistent_cache_set", lambda *_a, **_k: None)
+
+    captured = {}
+
+    class _Prov:
+        def complete_structured(self, **kwargs):
+            captured["prompt"] = kwargs["prompt"]
+            return {"sentiment": 0.4, "summary": "偏正", "impact": "short", "key_events": []}
+
+    monkeypatch.setattr(sentiment, "get_provider", lambda: _Prov())
+
+    res = sentiment.analyze_news(
+        [
+            "兆易创新发布业绩预增公告",
+            "长鑫科技上市在即：撑起3万亿产业链",
+            "主力资金净流入这些股",
+        ],
+        symbol="603986",
+        company_aliases=["兆易创新", "603986"],
+    )
+
+    assert res["sentiment"] == 0.4
+    assert "兆易创新发布业绩预增公告" in captured["prompt"]
+    assert "长鑫科技上市在即" not in captured["prompt"]
+    assert "主力资金净流入" not in captured["prompt"]
+
+
+def test_backtest_news_cache_passes_company_aliases(monkeypatch, tmp_path, test_db):
+    from backend.backtest import news_cache
+    from backend.data.database import NewsItem, Stock
+
+    test_db.add(Stock(symbol="603986", name="兆易创新", market="CN", active=True))
+    test_db.add_all([
+        NewsItem(
+            symbol="603986",
+            title="长鑫科技上市在即：撑起3万亿产业链",
+            url="https://example.com/changxin",
+            published_at=datetime(2026, 6, 15, 10, 0, 0),
+            source="test",
+        ),
+        NewsItem(
+            symbol="603986",
+            title="兆易创新发布业绩预增公告",
+            url="https://example.com/giga",
+            published_at=datetime(2026, 6, 15, 11, 0, 0),
+            source="test",
+        ),
+    ])
+    test_db.commit()
+    monkeypatch.setattr(news_cache, "_CACHE_FILE", tmp_path / "sentiment-cache.json")
+
+    captured = {}
+
+    def fake_analyze_news(titles, symbol, company_aliases=None):
+        captured["titles"] = titles
+        captured["symbol"] = symbol
+        captured["company_aliases"] = company_aliases
+        return {"sentiment": 0.0, "summary": "ok", "impact": "short", "key_events": []}
+
+    monkeypatch.setattr("backend.analysis.sentiment.analyze_news", fake_analyze_news)
+
+    news_cache.get_or_backfill("603986", "2026-06-15", test_db, use_llm=True)
+
+    assert captured["symbol"] == "603986"
+    assert captured["company_aliases"] == ["兆易创新", "603986"]
+    assert "兆易创新发布业绩预增公告" in captured["titles"]

--- a/tests/test_tavily_news.py
+++ b/tests/test_tavily_news.py
@@ -184,7 +184,7 @@ def test_postmarket_news_sentiment_skips_tavily_when_local_titles_meet_threshold
 
     monkeypatch.setattr("backend.data.news.fetch_titles_tavily", fake_tavily)
 
-    def fake_analyze_news(titles, symbol):
+    def fake_analyze_news(titles, symbol, company_aliases=None):
         captured["titles"] = titles
         return {"sentiment": 0.0}
 


### PR DESCRIPTION
## 背景
2026-06-15 M27 情感 IC 诊断的落地。`event_taxonomy` 的 `0.65×事件极性` 覆盖被量出**对 IC 净负**（event delta 三次测量 −0.0027 / −0.0146 / −0.0280），且非个股新闻驱动个股甩尾（兆易 603986：2 条板块 IPO 新闻、0 条公司新闻 → 情感 −71.3）。

## 改动（阶段0「便宜消融」，在现有标题管线上）
- **行情/资金流过滤**：`is_market_flow` / `is_company_specific` / `company_specific_titles`；市场/资金流/榜单标题在分类前剔除，避免「市场下滑」里的「下滑」误判成 `earnings_warning` 硬事件。
- **event_override 默认关**：`settings.sentiment_event_override_enabled`（默认 `False`）。事件类型仍上报（可观测），但不再混入分数。可为干净单 provider OOS 复测重新打开。
- **个股证据地板**：`analyze_news` 中，窗口无个股特定标题（仅噪声/跨公司，按 `company_aliases` 判）时返回中性 0 并**跳过 LLM 调用**（兼省成本）。
- **mixed-noise 收窄**：窗口里只要存在个股标题，就只把个股特定标题送入 LLM prompt/cache/event score，不再把跨公司/资金流标题一并送给 LLM。
- **历史回填覆盖**：生产 postmarket 和 backtest news-cache 路径都会在可用时传入股票名+代码别名，避免过滤只在生产盘后路径生效。
- **event-ab harness 强制 override ON**：让 `m27 --event-ab` 始终测量 override 的反事实 IC 效应，独立于生产默认值。

## 验证
- 本地相关测试：`46 passed / 1 skipped`
- 本地门禁：ruff clean、mypy clean、backend pytest `1224 passed / 6 skipped`
- 本地 frontend step：该 linked worktree 没有 `frontend/node_modules`，因此未在本地完成；GitHub Actions 的 frontend test/build 已通过。
- GitHub Actions：push 与 pull_request 两个 CI run 均通过 backend lint/typecheck、backend tests、frontend test/build、security/dependency audit。

## 性质与采用门槛
这是**防御性改动**：移除一个已测量的 IC 拖累 + 增加鲁棒性（灭兆易式甩尾），**不制造新情感 alpha**（情感原始 IC ~0.02 的天花板是输入数据决定的，需阶段1 完整 iFinD pack 才可能验证能否抬升）。

⚠️ **采用边界**：改动了镜像生产的情感行为 → **test2 epoch 重置**。合并/用于 live test2 信号前，应先做一次**干净单 provider OOS** 复测确认（与本会话纪律一致）。本 PR 不直接合并 main、不部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
