### PR TITLE
feat(sentiment): score news sentiment with capable tier (sonnet-4.6)

### DIFF
--- a/backend/analysis/sentiment.py
+++ b/backend/analysis/sentiment.py
@@ -209,7 +209,7 @@ def analyze_news(
         tool=_SENTIMENT_TOOL,
         system=SYSTEM_PROMPT,
         max_tokens=300,
-        model_tier="fast",
+        model_tier=settings.sentiment_model_tier,
     )
     try:
         import json as _json

--- a/backend/config.py
+++ b/backend/config.py
@@ -111,6 +111,12 @@ class Settings(BaseSettings):
     # variant tested (-0.0027 / -0.0146 / -0.0280), i.e. the override only subtracts IC.
     # Kept behind a flag so it can be re-enabled for a clean single-provider OOS re-test.
     sentiment_event_override_enabled: bool = False
+    # Model tier for news sentiment scoring. "capable" → claude-sonnet-4-6 on every
+    # provider. The 2026-06-15 clean single-provider OOS measured sentiment IC 0.0735
+    # under sonnet-4.6 vs ~0.020 under the "fast"/Codex tier — provider quality is the
+    # dominant lever for this signal. NOTE: with AI_PROVIDER=local_cli also set
+    # LOCAL_CLI_PREFER_CODEX=false, otherwise the Codex path ignores this model.
+    sentiment_model_tier: str = "capable"
 
     # Signal profile: legacy Qlib framework or current new framework.
     paper_trading_profile: str = "auto"  # auto / test1_legacy_qlib / new_framework

--- a/backend/tools/m27_sentiment_cache_backfill.py
+++ b/backend/tools/m27_sentiment_cache_backfill.py
@@ -170,13 +170,15 @@ def _call_llm_sentiment(titles: list[str], symbol: str) -> dict[str, Any]:
     if not has_runtime_llm_provider():
         readiness = runtime_readiness()
         raise RuntimeError(f"runtime LLM provider is not usable: {readiness.get('reason')}")
+    from backend.config import settings
+
     prompt = f"股票代码：{symbol}\n新闻标题：\n" + "\n".join(f"- {title}" for title in titles[:15])
     data = get_provider().complete_structured(
         prompt=prompt,
         tool=_SENTIMENT_TOOL,
         system=SYSTEM_PROMPT,
         max_tokens=300,
-        model_tier="fast",
+        model_tier=settings.sentiment_model_tier,
     )
     if not data:
         data = {"sentiment": 0.0, "summary": "解析失败", "impact": "short", "key_events": []}

--- a/tests/test_news_sentiment_pack.py
+++ b/tests/test_news_sentiment_pack.py
@@ -199,3 +199,28 @@ def test_backtest_news_cache_passes_company_aliases(monkeypatch, tmp_path, test_
     assert captured["symbol"] == "603986"
     assert captured["company_aliases"] == ["兆易创新", "603986"]
     assert "兆易创新发布业绩预增公告" in captured["titles"]
+
+
+def test_analyze_news_uses_configured_sentiment_model_tier(monkeypatch):
+    # Sentiment must score with the configured tier (default "capable" → sonnet-4.6),
+    # not the hardcoded "fast" tier. Clean OOS measured IC 0.0735 (sonnet) vs ~0.02 (fast).
+    from backend.config import settings
+
+    monkeypatch.setattr(sentiment, "has_runtime_llm_provider", lambda *_a, **_k: True)
+    monkeypatch.setattr(sentiment, "_cache_get", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_persistent_cache_get", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_cache_set", lambda *_a, **_k: None)
+    monkeypatch.setattr(sentiment, "_persistent_cache_set", lambda *_a, **_k: None)
+    monkeypatch.setattr(settings, "sentiment_model_tier", "capable")
+
+    captured = {}
+
+    class _Prov:
+        def complete_structured(self, **kwargs):
+            captured["model_tier"] = kwargs.get("model_tier")
+            return {"sentiment": 0.3, "summary": "ok", "impact": "short", "key_events": []}
+
+    monkeypatch.setattr(sentiment, "get_provider", lambda: _Prov())
+
+    sentiment.analyze_news(["兆易创新发布业绩预增公告"], symbol="603986")
+    assert captured["model_tier"] == "capable"


### PR DESCRIPTION
**Stacked on #20**（base = `feat/news-sentiment-pack`）。从新闻层 PR 拆出，单独 review/合并，因为它**改模型/成本行为**，风险类与纯防御的新闻层加固不同。#20 合并后本 PR 自动 retarget 到 main。

## 内容（仅 4 文件）
- `config.py`：新增 `sentiment_model_tier`（默认 `capable` → `claude-sonnet-4-6`，每个 provider 都映射到它）。
- `analyze_news` + m27 backfill：`model_tier` 从硬编码 `fast` 改为读配置。
- 测试：断言情感按配置档打分。

## 依据
2026-06-15 干净单 provider OOS：sentiment IC **0.0735@sonnet-4.6** vs **~0.020@fast/Codex** —— 打分模型质量是该信号的最大杠杆。

## ⚠️ 生产启用需配 env（.env 未提交）
- `AI_PROVIDER=anthropic`（云 API 付费、稳，适合 88 股日批）；或
- `AI_PROVIDER=local_cli` + `LOCAL_CLI_PREFER_CODEX=false`（走 claude CLI / CC 订阅免 API 费，但批量有日配额截断风险）。
- 不配则 `local_cli` 默认仍走 Codex，本改动不生效。

CI：随 PR 运行。`Security/dependency audit` 的 fail 是 `cryptography 48.0.0`→48.0.1 等依赖 CVE，与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)